### PR TITLE
Update title when performing and canceling a search

### DIFF
--- a/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
+++ b/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
@@ -310,6 +310,7 @@ extension UnsplashPhotoPickerViewController: UISearchBarDelegate {
         refresh()
         scrollToTop()
         hideEmptyView()
+        updateTitle()
         updateDoneButtonState()
     }
 
@@ -322,6 +323,7 @@ extension UnsplashPhotoPickerViewController: UISearchBarDelegate {
         reloadData()
         scrollToTop()
         hideEmptyView()
+        updateTitle()
         updateDoneButtonState()
     }
 }


### PR DESCRIPTION
Steps to reproduce when performing a search:
- select a few photos, the title is updated (e.g. "x photos selected"),
- perform a search,
- the title is not updated, it should be "Unsplash".

Same when canceling a search:
- perform a search,
- select a few photos, the title is updated (e.g. "x photos selected"),
- cancel the search,
- the title is not updated, it should be "Unsplash".

This PR fixes this problem.