### PR TITLE
Hide keyboard when scrolling

### DIFF
--- a/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
+++ b/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
@@ -326,6 +326,15 @@ extension UnsplashPhotoPickerViewController: UISearchBarDelegate {
     }
 }
 
+// MARK: - UIScrollViewDelegate
+extension UnsplashPhotoPickerViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if searchController.searchBar.isFirstResponder {
+            searchController.searchBar.resignFirstResponder()
+        }
+    }
+}
+
 // MARK: - PagedDataSourceDelegate
 extension UnsplashPhotoPickerViewController: PagedDataSourceDelegate {
     func dataSourceWillStartFetching(_ dataSource: PagedDataSource) {


### PR DESCRIPTION
It would be better to hide the keyboard as soon as the user starts to scroll to have more photos visible on the screen.