### PR TITLE
Remove cancel button from search bar

### DIFF
--- a/UnsplashPhotoPicker/UnsplashPhotoPicker.xcodeproj/project.pbxproj
+++ b/UnsplashPhotoPicker/UnsplashPhotoPicker.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		23A0D24A216D9D2400BEAE05 /* URL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A0D249216D9D2400BEAE05 /* URL+Extensions.swift */; };
 		23B683C0216BF83200CAA546 /* UnsplashPhotoPicker.h in Headers */ = {isa = PBXBuildFile; fileRef = 23B683BE216BF83200CAA546 /* UnsplashPhotoPicker.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		23C24A71217D3BBC00C03E7B /* EmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23C24A70217D3BBC00C03E7B /* EmptyView.swift */; };
+		23C288F421BF450800D97A3B /* UnsplashSearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23C288F321BF450800D97A3B /* UnsplashSearchController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -92,6 +93,7 @@
 		23B683BE216BF83200CAA546 /* UnsplashPhotoPicker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnsplashPhotoPicker.h; sourceTree = "<group>"; };
 		23B683BF216BF83200CAA546 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		23C24A70217D3BBC00C03E7B /* EmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyView.swift; sourceTree = "<group>"; };
+		23C288F321BF450800D97A3B /* UnsplashSearchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsplashSearchController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -137,6 +139,7 @@
 				23A0D1F0216D74B000BEAE05 /* UnsplashPhotoPickerViewController.swift */,
 				2333E0EB21757C52000B1900 /* UnsplashPhotoPickerViewController+UICollectionView.swift */,
 				231D12E8218FCD0E002C5750 /* UnsplashPhotoPickerPreviewViewController.swift */,
+				23C288F321BF450800D97A3B /* UnsplashSearchController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -373,6 +376,7 @@
 				23A0D21C216D825B00BEAE05 /* Configuration.swift in Sources */,
 				23A0D228216D8AD600BEAE05 /* SearchPhotosRequest.swift in Sources */,
 				23A0D22B216D8AD600BEAE05 /* GetCollectionPhotosRequest.swift in Sources */,
+				23C288F421BF450800D97A3B /* UnsplashSearchController.swift in Sources */,
 				23A0D20B216D806800BEAE05 /* Dictionary+Extensions.swift in Sources */,
 				23A0D1F3216D74C800BEAE05 /* UnsplashPhotoPicker.swift in Sources */,
 				2333E0F021758899000B1900 /* ImageDownloader.swift in Sources */,

--- a/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
+++ b/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
@@ -34,7 +34,7 @@ class UnsplashPhotoPickerViewController: UIViewController {
     }()
 
     private lazy var searchController: UISearchController = {
-        let searchController = UISearchController(searchResultsController: nil)
+        let searchController = UnsplashSearchController(searchResultsController: nil)
         searchController.obscuresBackgroundDuringPresentation = false
         searchController.hidesNavigationBarDuringPresentation = false
         searchController.searchBar.delegate = self
@@ -313,11 +313,11 @@ extension UnsplashPhotoPickerViewController: UISearchBarDelegate {
         updateDoneButtonState()
     }
 
-    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
-        guard searchText != nil else { return }
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        guard self.searchText != nil && searchText.isEmpty else { return }
 
         dataSource = editorialDataSource
-        searchText = nil
+        self.searchText = nil
         refresh()
         reloadData()
         scrollToTop()

--- a/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashSearchController.swift
+++ b/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashSearchController.swift
@@ -1,0 +1,23 @@
+//
+//  UnsplashSearchController.swift
+//  UnsplashPhotoPicker
+//
+//  Created by Bichon, Nicolas on 2018-12-10.
+//  Copyright © 2018 Unsplash. All rights reserved.
+//
+
+import UIKit
+
+class UnsplashSearchController: UISearchController {
+    lazy var customSearchBar = CustomSearchBar(frame: CGRect.zero)
+
+    override var searchBar: UISearchBar {
+        return customSearchBar
+    }
+}
+
+class CustomSearchBar: UISearchBar {
+    override func setShowsCancelButton(_ showsCancelButton: Bool, animated: Bool) {
+        super.setShowsCancelButton(false, animated: false)
+    }
+}


### PR DESCRIPTION
A solution to avoid having 2 "cancel" buttons on the screen at the same time.

I prevent the cancel button from appearing next to the search bar when the user taps on it. Tapping the "x" has the same effect as taping the "cancel" button before, it displays the editorial collection.

![comparison](https://user-images.githubusercontent.com/1519558/49772051-baec5580-fcb9-11e8-9031-d5c16f7e8b69.png)
