### PR TITLE
Verify entire result set to display empty result state

### DIFF
--- a/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
+++ b/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
@@ -335,7 +335,7 @@ extension UnsplashPhotoPickerViewController: PagedDataSourceDelegate {
     }
 
     func dataSource(_ dataSource: PagedDataSource, didFetch items: [UnsplashPhoto]) {
-        guard items.count > 0 else {
+        guard dataSource.items.count > 0 else {
             DispatchQueue.main.async {
                 self.spinner.stopAnimating()
                 self.showEmptyView(with: .noResults)


### PR DESCRIPTION
When the data source fetches items, verify if the entire result set is empty, instead of just the latest, to display the empty result state.