### PR TITLE
Fix content offset when cancel search

### DIFF
--- a/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
+++ b/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
@@ -243,7 +243,8 @@ class UnsplashPhotoPickerViewController: UIViewController {
     }
 
     private func scrollToTop() {
-        collectionView.setContentOffset(.zero, animated: false)
+        let contentOffset = CGPoint(x: 0, y: -collectionView.safeAreaInsets.top)
+        collectionView.setContentOffset(contentOffset, animated: false)
     }
 
     // MARK: - Data


### PR DESCRIPTION
Steps to reproduce:

- perform a search
- scroll down
- tap "cancel" button in the search bar
- the content offset of the collection view is incorrect