### PR TITLE
Fix incorrect display of UIActivityIndicatorView when dark theme in iOS 13

### DIFF
--- a/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
+++ b/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
@@ -61,10 +61,17 @@ class UnsplashPhotoPickerViewController: UIViewController {
     }()
 
     private let spinner: UIActivityIndicatorView = {
-        let spinner = UIActivityIndicatorView(style: .gray)
-        spinner.translatesAutoresizingMaskIntoConstraints = false
-        spinner.hidesWhenStopped = true
-        return spinner
+        if #available(iOS 13.0, *) {
+            let spinner = UIActivityIndicatorView(style: .medium)
+            spinner.translatesAutoresizingMaskIntoConstraints = false
+            spinner.hidesWhenStopped = true
+            return spinner
+        } else {
+            let spinner = UIActivityIndicatorView(style: .gray)
+            spinner.translatesAutoresizingMaskIntoConstraints = false
+            spinner.hidesWhenStopped = true
+            return spinner
+        }
     }()
 
     private lazy var emptyView: EmptyView = {


### PR DESCRIPTION
UIActivityIndicatorView has a new style in iOS 13, if you use the old style (style: .gray) in iOS 13 when switching to a dark theme, the spinner will be very poorly visible. I propose using it in iOS 13 (style: .medium), and in all other cases (style: .gray).

_Sorry, I had to create another pull request, I forgot to highlight all the changes in another branch)_