### PR TITLE
Fixed logic for requesting thumbnails at the correct size for the PhotoView in the collection view

### DIFF
--- a/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Views/PhotoView.swift
+++ b/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Views/PhotoView.swift
@@ -78,12 +78,10 @@ class PhotoView: UIView {
     }
 
     private func sizedImageURL(from url: URL) -> URL {
-        let width: CGFloat = frame.width * screenScale
-        let height: CGFloat = frame.height * screenScale
-
+        layoutIfNeeded()
         return url.appending(queryItems: [
-            URLQueryItem(name: "max-w", value: "\(width)"),
-            URLQueryItem(name: "max-h", value: "\(height)")
+            URLQueryItem(name: "w", value: "\(frame.width)"),
+            URLQueryItem(name: "dpr", value: "\(Int(screenScale))"),
         ])
     }
 


### PR DESCRIPTION
Setting max-w and max-h in the original code was not actually doing anything. 
From the imgix docs: "This parameter will only work if fit=crop is present"
So thumbnails were actually downloaded at 1080w, which in many cases is much larger than necessary, causing unnecessary network and CPU usage. 
The call to layoutIfNeeded is required to let Autolayout compute the correct size for the PhotoView first.