### PR TITLE
Flicker issue with some searches, eg: "boredom"

### DIFF
--- a/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
+++ b/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
@@ -384,6 +384,7 @@ extension UnsplashPhotoPickerViewController: PagedDataSourceDelegate {
     }
 
     func dataSource(_ dataSource: PagedDataSource, didFetch items: [UnsplashPhoto]) {
+        guard items.count > 0 else { return }
         guard dataSource.items.count > 0 else {
             DispatchQueue.main.async {
                 self.spinner.stopAnimating()


### PR DESCRIPTION
When searching for "boredom" and scrolling down and up, there is an infinite flicker going on.This should fix that